### PR TITLE
Add cssInjectedByJsPlugin in vite plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "styled-components": "^5.3.9",
     "typescript": "^4.9.3",
     "vite": "^4.2.0",
+    "vite-plugin-css-injected-by-js": "^3.1.0",
     "vite-plugin-dts": "^2.2.0"
   },
   "main": "./dist/fancy-text.umd.js",

--- a/src/lib/FancyText/FancyText.tsx
+++ b/src/lib/FancyText/FancyText.tsx
@@ -8,20 +8,21 @@ const fontSizes = {
   lg: "16rem",
 } satisfies Record<Size,string>;
 
+const StyledH1 = styled.h1<{ size: Size }>`
+margin-top: 0px;
+margin-bottom: 8px;
+text-shadow: 3px 3px #011627;
+font-family: sans-serif;
+color: #FFF;
+font-size: ${({ size  }) => fontSizes[size]};`;
+
 type FancyTextProps = { text: string , size?: Size};
 
 const FancyText: FC<FancyTextProps> = ({ text ,size="md" }) => {
   const words = text.split(" ");
-  const StylesH1 = styled.h1<{ size: Size }>`
-  margin-top: 0px;
-  margin-bottom: 8px;
-  text-shadow: 3px 3px #011627;
-  font-family: sans-serif;
-  color: #FFF;
-  font-size: ${({ size  }) => fontSizes[size]};`;
 
   return (
-    <StylesH1 size={size}>
+    <StyledH1 size={size}>
       {words.map((word) => (
         <span
           key={word}
@@ -39,7 +40,7 @@ const FancyText: FC<FancyTextProps> = ({ text ,size="md" }) => {
           {word}
         </span>
       ))}
-    </StylesH1>
+    </StyledH1>
   );
 };
 

--- a/src/lib/Roses/Roses.tsx
+++ b/src/lib/Roses/Roses.tsx
@@ -1,5 +1,7 @@
 import { FC } from "react";
 import styled from "styled-components";
+import './main.css';
+
 type Size = "sm" | "md" | "lg";
 const fontSizes = {
   sm: "4rem",
@@ -12,18 +14,19 @@ const textShadow = {
   lg: `5px 5px 0px #eb452b, 10px 10px 0px #efa032, 15px 15px 0px #46b59b, 20px 20px 0px #017e7f, 25px 25px 0px #052939`
 } satisfies Record<Size,string>;
 
+const StyledDiv = styled.div<{ size: Size }>`
+font-size: ${({ size  }) => fontSizes[size]};
+color: #fcedd8;
+font-family: Niconne, cursive;
+font-weight: 700;
+text-shadow: ${({ size  }) => textShadow[size]};
+`;
+
 type RosesProps = {
   text: string;
   size?: Size;
 };
 const Roses: FC<RosesProps> = ({ text, size = "md" }) => {
-  const StyledDiv = styled.div<{ size: Size }>`
-    font-size: ${({ size  }) => fontSizes[size]};
-    color: #fcedd8;
-    font-family: "Niconne", cursive;
-    font-weight: 700;
-    text-shadow: ${({ size  }) => textShadow[size]};
-  `;
   return <StyledDiv size={size}>{text}</StyledDiv>;
 };
 

--- a/src/lib/Roses/main.css
+++ b/src/lib/Roses/main.css
@@ -1,0 +1,1 @@
+@import url(https://fonts.googleapis.com/css?family=Niconne);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import react from '@vitejs/plugin-react';
 import path from 'node:path';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
+import cssInjectedByJsPlugin from "vite-plugin-css-injected-by-js";
 
 export default defineConfig({
   plugins: [
@@ -9,6 +10,7 @@ export default defineConfig({
     dts({
       insertTypesEntry: true,
     }),
+    cssInjectedByJsPlugin(),
   ],
   build: {
     lib: {


### PR DESCRIPTION
This plugin is added so that css in css files are injected in final build.

**Needs Improvement** 
This will merge together all CSS in different files and adds them inline to the final JS bundle files. This is not optimum.
For eg. If the consumer of the library only uses one Fancy text, still he will be forced to fetch all other font files imported using @import in different CSS files. 

Optimisation is tracked in the issue #9 